### PR TITLE
Rename Item to Resource with description, type, and inline editing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+This is a workshop monorepo (npm workspaces) for learning AI-assisted development. The app is a **booking/resource management system** with:
+
+- `api/` — Hono REST API with Prisma ORM and SQLite
+- `web/` — React + Vite + TailwindCSS v4 frontend
+
+## Commands
+
+All commands run from the repo root unless noted.
+
+```bash
+npm run dev           # Start both API (port 3000) and web (port 5173) concurrently
+npm run dev:api       # API only
+npm run dev:web       # Web only (assumes API is already running)
+npm run generate      # Regenerate Prisma client + export OpenAPI + regenerate Orval hooks
+npm run build         # Build all workspaces
+npm run typecheck     # Type-check all workspaces
+```
+
+Reset the database:
+```bash
+rm api/data/workshop.db && npm run dev
+```
+
+Inspect the database (browser UI at port 5555):
+```bash
+npx prisma studio --schema api/prisma/schema.prisma
+```
+
+## Code generation pipeline
+
+The API contract flows through three steps; **run `npm run generate` after any schema or route change**:
+
+1. `prisma generate` — generates Prisma client from `api/prisma/schema.prisma`
+2. `api/scripts/export-openapi.ts` — exports the live OpenAPI spec to `api/openapi.json`
+3. Orval reads `api/openapi.json` and writes TanStack Query hooks to `web/src/api/generated/hooks.ts`
+
+## Architecture
+
+### API (`api/src/app.ts`)
+
+All routes are defined schema-first using `@hono/zod-openapi`. Each route is a `createRoute(...)` call with Zod request/response schemas, then registered via `app.openapi(route, handler)`. The OpenAPI spec is served live at `/openapi.json`. This schema-first pattern means route types and OpenAPI docs are always in sync.
+
+### Web (`web/src/`)
+
+The frontend consumes only the generated hooks from `web/src/api/generated/hooks.ts` — never hand-writes fetch calls. The custom Axios client in `web/src/api/client.ts` uses `/api` as the base URL; Vite proxies that to `http://localhost:3000` in development (stripping the `/api` prefix). The proxy target can be overridden via the `VITE_API_PROXY_TARGET` env var.
+
+### Environment variables
+
+| Variable | Where | Purpose |
+|---|---|---|
+| `API_PORT` | root | Override API port (default 3000) |
+| `CORS_ORIGIN` | `api/` | Comma-separated allowed CORS origins for deployed frontends |
+| `VITE_API_PROXY_TARGET` | `web/` | Override API proxy target (default `http://localhost:3000`) |

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -36,7 +36,7 @@
           "status"
         ]
       },
-      "Item": {
+      "Resource": {
         "type": "object",
         "properties": {
           "id": {
@@ -47,7 +47,16 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 120,
-            "example": "Build a workshop API"
+            "example": "Conference Room A"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 500,
+            "example": "Large meeting room with a projector"
+          },
+          "resourceType": {
+            "type": "string",
+            "example": "room"
           },
           "createdAt": {
             "type": "string",
@@ -58,36 +67,83 @@
         "required": [
           "id",
           "title",
+          "description",
+          "resourceType",
           "createdAt"
         ]
       },
-      "ItemListResponse": {
+      "ResourceListResponse": {
         "type": "object",
         "properties": {
-          "items": {
+          "resources": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Item"
+              "$ref": "#/components/schemas/Resource"
             }
           }
         },
         "required": [
-          "items"
+          "resources"
         ]
       },
-      "CreateItem": {
+      "CreateResource": {
         "type": "object",
         "properties": {
           "title": {
             "type": "string",
             "minLength": 1,
             "maxLength": 120,
-            "example": "Build a workshop API"
+            "example": "Conference Room A"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 500,
+            "default": "",
+            "example": "Large meeting room with a projector"
+          },
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "general",
+              "room",
+              "equipment",
+              "vehicle",
+              "person"
+            ],
+            "default": "general",
+            "example": "room"
           }
         },
         "required": [
           "title"
         ]
+      },
+      "UpdateResource": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120,
+            "example": "Conference Room A"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 500,
+            "example": "Large meeting room with a projector"
+          },
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "general",
+              "room",
+              "equipment",
+              "vehicle",
+              "person"
+            ],
+            "example": "room"
+          }
+        }
       }
     },
     "parameters": {}
@@ -131,18 +187,18 @@
         }
       }
     },
-    "/items": {
+    "/resources": {
       "get": {
         "tags": [
-          "Items"
+          "Resources"
         ],
         "responses": {
           "200": {
-            "description": "List persisted items",
+            "description": "List persisted resources",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ItemListResponse"
+                  "$ref": "#/components/schemas/ResourceListResponse"
                 }
               }
             }
@@ -151,25 +207,25 @@
       },
       "post": {
         "tags": [
-          "Items"
+          "Resources"
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateItem"
+                "$ref": "#/components/schemas/CreateResource"
               }
             }
           }
         },
         "responses": {
           "201": {
-            "description": "Create a persisted item",
+            "description": "Create a persisted resource",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Item"
+                  "$ref": "#/components/schemas/Resource"
                 }
               }
             }
@@ -177,10 +233,53 @@
         }
       }
     },
-    "/items/{id}": {
+    "/resources/{id}": {
+      "patch": {
+        "tags": [
+          "Resources"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "example": 1
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Update a persisted resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resource"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found"
+          }
+        }
+      },
       "delete": {
         "tags": [
-          "Items"
+          "Resources"
         ],
         "parameters": [
           {
@@ -197,7 +296,7 @@
         ],
         "responses": {
           "204": {
-            "description": "Remove a persisted item"
+            "description": "Remove a persisted resource"
           }
         }
       }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -297,6 +297,9 @@
         "responses": {
           "204": {
             "description": "Remove a persisted resource"
+          },
+          "404": {
+            "description": "Resource not found"
           }
         }
       }

--- a/api/prisma/migrations/20260423112339_add_resource/migration.sql
+++ b/api/prisma/migrations/20260423112339_add_resource/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Item` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "Item";
+PRAGMA foreign_keys=on;
+
+-- CreateTable
+CREATE TABLE "Resource" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "resourceType" TEXT NOT NULL DEFAULT 'general',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -7,8 +7,10 @@ datasource db {
   url      = "file:../data/workshop.db"
 }
 
-model Item {
-  id        Int      @id @default(autoincrement())
-  title     String
-  createdAt DateTime @default(now())
+model Resource {
+  id           Int      @id @default(autoincrement())
+  title        String
+  description  String   @default("")
+  resourceType String   @default("general")
+  createdAt    DateTime @default(now())
 }

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -11,21 +11,33 @@ const HealthResponseSchema = z.object({
   status: z.literal('ok')
 }).openapi('HealthResponse')
 
-const ItemSchema = z.object({
+const RESOURCE_TYPES = ['general', 'room', 'equipment', 'vehicle', 'person'] as const
+
+const ResourceSchema = z.object({
   id: z.number().int().openapi({ example: 1 }),
-  title: z.string().min(1).max(120).openapi({ example: 'Build a workshop API' }),
+  title: z.string().min(1).max(120).openapi({ example: 'Conference Room A' }),
+  description: z.string().max(500).openapi({ example: 'Large meeting room with a projector' }),
+  resourceType: z.string().openapi({ example: 'room' }),
   createdAt: z.string().datetime().openapi({ example: '2024-01-01T00:00:00.000Z' })
-}).openapi('Item')
+}).openapi('Resource')
 
-const ItemListResponseSchema = z.object({
-  items: z.array(ItemSchema)
-}).openapi('ItemListResponse')
+const ResourceListResponseSchema = z.object({
+  resources: z.array(ResourceSchema)
+}).openapi('ResourceListResponse')
 
-const CreateItemSchema = z.object({
-  title: z.string().trim().min(1).max(120).openapi({ example: 'Build a workshop API' })
-}).openapi('CreateItem')
+const CreateResourceSchema = z.object({
+  title: z.string().trim().min(1).max(120).openapi({ example: 'Conference Room A' }),
+  description: z.string().trim().max(500).default('').openapi({ example: 'Large meeting room with a projector' }),
+  resourceType: z.enum(RESOURCE_TYPES).default('general').openapi({ example: 'room' })
+}).openapi('CreateResource')
 
-const ItemParamsSchema = z.object({
+const UpdateResourceSchema = z.object({
+  title: z.string().trim().min(1).max(120).optional().openapi({ example: 'Conference Room A' }),
+  description: z.string().trim().max(500).optional().openapi({ example: 'Large meeting room with a projector' }),
+  resourceType: z.enum(RESOURCE_TYPES).optional().openapi({ example: 'room' })
+}).openapi('UpdateResource')
+
+const ResourceParamsSchema = z.object({
   id: z.coerce.number().int().positive().openapi({
     param: {
       name: 'id',
@@ -33,7 +45,7 @@ const ItemParamsSchema = z.object({
     },
     example: 1
   })
-}).openapi('ItemParams')
+}).openapi('ResourceParams')
 
 const rootRoute = createRoute({
   method: 'get',
@@ -67,66 +79,104 @@ const healthRoute = createRoute({
   }
 })
 
-const listItemsRoute = createRoute({
+const listResourcesRoute = createRoute({
   method: 'get',
-  path: '/items',
-  tags: ['Items'],
+  path: '/resources',
+  tags: ['Resources'],
   responses: {
     200: {
-      description: 'List persisted items',
+      description: 'List persisted resources',
       content: {
         'application/json': {
-          schema: ItemListResponseSchema
+          schema: ResourceListResponseSchema
         }
       }
     }
   }
 })
 
-const createItemRoute = createRoute({
+const createResourceRoute = createRoute({
   method: 'post',
-  path: '/items',
-  tags: ['Items'],
+  path: '/resources',
+  tags: ['Resources'],
   request: {
     body: {
       required: true,
       content: {
         'application/json': {
-          schema: CreateItemSchema
+          schema: CreateResourceSchema
         }
       }
     }
   },
   responses: {
     201: {
-      description: 'Create a persisted item',
+      description: 'Create a persisted resource',
       content: {
         'application/json': {
-          schema: ItemSchema
+          schema: ResourceSchema
         }
       }
     }
   }
 })
 
-const deleteItemRoute = createRoute({
-  method: 'delete',
-  path: '/items/{id}',
-  tags: ['Items'],
+const updateResourceRoute = createRoute({
+  method: 'patch',
+  path: '/resources/{id}',
+  tags: ['Resources'],
   request: {
-    params: ItemParamsSchema
+    params: ResourceParamsSchema,
+    body: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: UpdateResourceSchema
+        }
+      }
+    }
   },
   responses: {
-    204: {
-      description: 'Remove a persisted item'
+    200: {
+      description: 'Update a persisted resource',
+      content: {
+        'application/json': {
+          schema: ResourceSchema
+        }
+      }
+    },
+    404: {
+      description: 'Resource not found'
     }
   }
 })
 
-const toItemResponse = (item: { id: number; title: string; createdAt: Date }) => ({
-  id: item.id,
-  title: item.title,
-  createdAt: item.createdAt.toISOString()
+const deleteResourceRoute = createRoute({
+  method: 'delete',
+  path: '/resources/{id}',
+  tags: ['Resources'],
+  request: {
+    params: ResourceParamsSchema
+  },
+  responses: {
+    204: {
+      description: 'Remove a persisted resource'
+    }
+  }
+})
+
+const toResourceResponse = (resource: {
+  id: number
+  title: string
+  description: string
+  resourceType: string
+  createdAt: Date
+}) => ({
+  id: resource.id,
+  title: resource.title,
+  description: resource.description,
+  resourceType: resource.resourceType,
+  createdAt: resource.createdAt.toISOString()
 })
 
 const defaultCorsOrigins = ['http://localhost:4173', 'http://localhost:5173']
@@ -165,33 +215,52 @@ app.openapi(healthRoute, (c) => {
   }, 200)
 })
 
-app.openapi(listItemsRoute, async (c) => {
-  const items = await prisma.item.findMany({
+app.openapi(listResourcesRoute, async (c) => {
+  const resources = await prisma.resource.findMany({
     orderBy: {
       createdAt: 'desc'
     }
   })
 
   return c.json({
-    items: items.map(toItemResponse)
+    resources: resources.map(toResourceResponse)
   }, 200)
 })
 
-app.openapi(createItemRoute, async (c) => {
-  const { title } = c.req.valid('json')
-  const item = await prisma.item.create({
+app.openapi(createResourceRoute, async (c) => {
+  const { title, description, resourceType } = c.req.valid('json')
+  const resource = await prisma.resource.create({
     data: {
-      title
+      title,
+      description,
+      resourceType
     }
   })
 
-  return c.json(toItemResponse(item), 201)
+  return c.json(toResourceResponse(resource), 201)
 })
 
-app.openapi(deleteItemRoute, async (c) => {
+app.openapi(updateResourceRoute, async (c) => {
+  const { id } = c.req.valid('param')
+  const updates = c.req.valid('json')
+
+  const existing = await prisma.resource.findUnique({ where: { id } })
+  if (!existing) {
+    return c.body(null, 404)
+  }
+
+  const resource = await prisma.resource.update({
+    where: { id },
+    data: updates
+  })
+
+  return c.json(toResourceResponse(resource), 200)
+})
+
+app.openapi(deleteResourceRoute, async (c) => {
   const { id } = c.req.valid('param')
 
-  await prisma.item.deleteMany({
+  await prisma.resource.deleteMany({
     where: {
       id
     }

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi'
 import { cors } from 'hono/cors'
+import { Prisma } from '@prisma/client'
 import { prisma } from './db.js'
 
 const RootResponseSchema = z.object({
@@ -161,6 +162,9 @@ const deleteResourceRoute = createRoute({
   responses: {
     204: {
       description: 'Remove a persisted resource'
+    },
+    404: {
+      description: 'Resource not found'
     }
   }
 })
@@ -260,11 +264,14 @@ app.openapi(updateResourceRoute, async (c) => {
 app.openapi(deleteResourceRoute, async (c) => {
   const { id } = c.req.valid('param')
 
-  await prisma.resource.deleteMany({
-    where: {
-      id
+  try {
+    await prisma.resource.delete({ where: { id } })
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+      return c.body(null, 404)
     }
-  })
+    throw e
+  }
 
   return c.body(null, 204)
 })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,130 +1,296 @@
 import { type FormEvent, useState } from "react";
 import {
-  getGetItemsQueryKey,
-  useDeleteItemsId,
-  useGetItems,
-  usePostItems,
+  CreateResourceResourceType,
+  getGetResourcesQueryKey,
+  useDeleteResourcesId,
+  useGetResources,
+  usePatchResourcesId,
+  usePostResources,
+  type Resource,
 } from "./api";
 import { useQueryClient } from "@tanstack/react-query";
 
+const RESOURCE_TYPE_LABELS: Record<string, string> = {
+  general: "General",
+  room: "Room",
+  equipment: "Equipment",
+  vehicle: "Vehicle",
+  person: "Person",
+};
+
+type EditState = {
+  id: number;
+  title: string;
+  description: string;
+  resourceType: string;
+};
+
 export default function App() {
   const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [resourceType, setResourceType] = useState<string>("general");
+  const [editState, setEditState] = useState<EditState | null>(null);
+
   const queryClient = useQueryClient();
-  const refreshItems = () =>
-    queryClient.invalidateQueries({ queryKey: getGetItemsQueryKey() });
-  const itemsQuery = useGetItems();
-  const createItemMutation = usePostItems({
+  const refreshResources = () =>
+    queryClient.invalidateQueries({ queryKey: getGetResourcesQueryKey() });
+
+  const resourcesQuery = useGetResources();
+
+  const createMutation = usePostResources({
     mutation: {
       onSuccess: async () => {
         setTitle("");
-        await refreshItems();
+        setDescription("");
+        setResourceType("general");
+        await refreshResources();
       },
     },
   });
-  const deleteItemMutation = useDeleteItemsId({
+
+  const updateMutation = usePatchResourcesId({
     mutation: {
-      onSuccess: refreshItems,
+      onSuccess: async () => {
+        setEditState(null);
+        await refreshResources();
+      },
+    },
+  });
+
+  const deleteMutation = useDeleteResourcesId({
+    mutation: {
+      onSuccess: refreshResources,
     },
   });
 
   const trimmedTitle = title.trim();
-  const items = itemsQuery.data?.items ?? [];
-  const deletingItemId = deleteItemMutation.variables?.id;
+  const resources = resourcesQuery.data?.resources ?? [];
+  const deletingId = deleteMutation.variables?.id;
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleCreate = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (!trimmedTitle || createMutation.isPending) return;
 
-    if (!trimmedTitle || createItemMutation.isPending) {
-      return;
-    }
-
-    createItemMutation.mutate({
+    createMutation.mutate({
       data: {
         title: trimmedTitle,
-        },
-      });
+        description: description.trim(),
+        resourceType: resourceType as "general" | "room" | "equipment" | "vehicle" | "person",
+      },
+    });
+  };
+
+  const handleEditOpen = (resource: Resource) => {
+    setEditState({
+      id: resource.id,
+      title: resource.title,
+      description: resource.description,
+      resourceType: resource.resourceType,
+    });
+  };
+
+  const handleEditSave = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editState || updateMutation.isPending) return;
+
+    const trimmed = editState.title.trim();
+    if (!trimmed) return;
+
+    updateMutation.mutate({
+      id: editState.id,
+      data: {
+        title: trimmed,
+        description: editState.description.trim(),
+        resourceType: editState.resourceType as "general" | "room" | "equipment" | "vehicle" | "person",
+      },
+    });
   };
 
   const handleRemove = (id: number) => {
-    if (deleteItemMutation.isPending) {
-      return;
-    }
-
-    deleteItemMutation.mutate({ id });
+    if (deleteMutation.isPending) return;
+    deleteMutation.mutate({ id });
   };
+
+  const resourceTypes = Object.values(CreateResourceResourceType);
 
   return (
     <main className="min-h-screen bg-slate-50 px-4 py-10 text-slate-900">
       <div className="mx-auto max-w-xl space-y-6">
         <header className="space-y-2">
-          <h1 className="text-2xl font-semibold">Workshop items</h1>
+          <h1 className="text-2xl font-semibold">Resources</h1>
           <p className="text-sm text-slate-600">
-            A simple add and remove list powered by the generated API hooks.
+            Manage bookable resources. Add, edit, or remove entries below.
           </p>
         </header>
 
         <form
-          className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:flex-row"
-          onSubmit={handleSubmit}
+          className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm"
+          onSubmit={handleCreate}
         >
+          <div className="flex gap-3">
+            <input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Resource name"
+              maxLength={120}
+              className="flex-1 rounded-md border border-slate-300 px-3 py-2 text-base outline-none focus:border-slate-500"
+            />
+            <select
+              value={resourceType}
+              onChange={(e) => setResourceType(e.target.value)}
+              className="rounded-md border border-slate-300 px-3 py-2 text-sm outline-none focus:border-slate-500"
+            >
+              {resourceTypes.map((t) => (
+                <option key={t} value={t}>
+                  {RESOURCE_TYPE_LABELS[t] ?? t}
+                </option>
+              ))}
+            </select>
+          </div>
           <input
-            value={title}
-            onChange={(event) => setTitle(event.target.value)}
-            placeholder="Add an item"
-            maxLength={120}
-            className="flex-1 rounded-md border border-slate-300 px-3 py-2 text-base outline-none focus:border-slate-500"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Description (optional)"
+            maxLength={500}
+            className="rounded-md border border-slate-300 px-3 py-2 text-base outline-none focus:border-slate-500"
           />
           <button
             type="submit"
-            disabled={!trimmedTitle || createItemMutation.isPending}
-            className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-slate-300"
+            disabled={!trimmedTitle || createMutation.isPending}
+            className="self-end rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-slate-300"
           >
-            {createItemMutation.isPending ? "Adding..." : "Add item"}
+            {createMutation.isPending ? "Adding..." : "Add resource"}
           </button>
         </form>
 
-        {createItemMutation.isError ? (
+        {createMutation.isError ? (
           <p className="text-sm text-rose-600">
-            Could not add the item: {createItemMutation.error.message}
+            Could not add the resource: {createMutation.error.message}
           </p>
         ) : null}
 
-        {deleteItemMutation.isError ? (
+        {deleteMutation.isError ? (
           <p className="text-sm text-rose-600">
-            Could not remove the item: {deleteItemMutation.error.message}
+            Could not remove the resource: {deleteMutation.error.message}
+          </p>
+        ) : null}
+
+        {updateMutation.isError ? (
+          <p className="text-sm text-rose-600">
+            Could not update the resource: {updateMutation.error.message}
           </p>
         ) : null}
 
         <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-          <h2 className="text-sm font-medium text-slate-700">Items</h2>
+          <h2 className="text-sm font-medium text-slate-700">All resources</h2>
 
-          {itemsQuery.isPending ? <p className="mt-3 text-sm text-slate-600">Loading items...</p> : null}
-
-          {itemsQuery.isError ? (
-            <p className="mt-3 text-sm text-rose-600">Could not load items: {itemsQuery.error.message}</p>
+          {resourcesQuery.isPending ? (
+            <p className="mt-3 text-sm text-slate-600">Loading resources...</p>
           ) : null}
 
-          {!itemsQuery.isPending && !itemsQuery.isError ? (
-            items.length > 0 ? (
+          {resourcesQuery.isError ? (
+            <p className="mt-3 text-sm text-rose-600">
+              Could not load resources: {resourcesQuery.error.message}
+            </p>
+          ) : null}
+
+          {!resourcesQuery.isPending && !resourcesQuery.isError ? (
+            resources.length > 0 ? (
               <ul className="mt-3 divide-y divide-slate-200">
-                {items.map((item) => (
-                  <li key={item.id} className="flex items-center justify-between gap-3 py-3">
-                    <span>{item.title}</span>
-                    <button
-                      type="button"
-                      onClick={() => handleRemove(item.id)}
-                      disabled={deleteItemMutation.isPending}
-                      className="rounded-md border border-slate-300 px-3 py-1 text-sm text-slate-700 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
-                    >
-                      {deleteItemMutation.isPending && deletingItemId === item.id
-                        ? "Removing..."
-                        : "Remove"}
-                    </button>
-                  </li>
-                ))}
+                {resources.map((resource) =>
+                  editState?.id === resource.id ? (
+                    <li key={resource.id} className="py-3">
+                      <form className="flex flex-col gap-2" onSubmit={handleEditSave}>
+                        <div className="flex gap-2">
+                          <input
+                            value={editState.title}
+                            onChange={(e) =>
+                              setEditState({ ...editState, title: e.target.value })
+                            }
+                            maxLength={120}
+                            className="flex-1 rounded-md border border-slate-300 px-3 py-1.5 text-sm outline-none focus:border-slate-500"
+                          />
+                          <select
+                            value={editState.resourceType}
+                            onChange={(e) =>
+                              setEditState({ ...editState, resourceType: e.target.value })
+                            }
+                            className="rounded-md border border-slate-300 px-2 py-1.5 text-sm outline-none focus:border-slate-500"
+                          >
+                            {resourceTypes.map((t) => (
+                              <option key={t} value={t}>
+                                {RESOURCE_TYPE_LABELS[t] ?? t}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <input
+                          value={editState.description}
+                          onChange={(e) =>
+                            setEditState({ ...editState, description: e.target.value })
+                          }
+                          maxLength={500}
+                          placeholder="Description (optional)"
+                          className="rounded-md border border-slate-300 px-3 py-1.5 text-sm outline-none focus:border-slate-500"
+                        />
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => setEditState(null)}
+                            className="rounded-md border border-slate-300 px-3 py-1 text-sm text-slate-700"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="submit"
+                            disabled={!editState.title.trim() || updateMutation.isPending}
+                            className="rounded-md bg-slate-900 px-3 py-1 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-slate-300"
+                          >
+                            {updateMutation.isPending ? "Saving..." : "Save"}
+                          </button>
+                        </div>
+                      </form>
+                    </li>
+                  ) : (
+                    <li key={resource.id} className="flex items-start justify-between gap-3 py-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">{resource.title}</span>
+                          <span className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-600">
+                            {RESOURCE_TYPE_LABELS[resource.resourceType] ?? resource.resourceType}
+                          </span>
+                        </div>
+                        {resource.description ? (
+                          <p className="mt-0.5 truncate text-sm text-slate-500">
+                            {resource.description}
+                          </p>
+                        ) : null}
+                      </div>
+                      <div className="flex shrink-0 gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleEditOpen(resource)}
+                          className="rounded-md border border-slate-300 px-3 py-1 text-sm text-slate-700"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleRemove(resource.id)}
+                          disabled={deleteMutation.isPending}
+                          className="rounded-md border border-slate-300 px-3 py-1 text-sm text-slate-700 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+                        >
+                          {deleteMutation.isPending && deletingId === resource.id
+                            ? "Removing..."
+                            : "Remove"}
+                        </button>
+                      </div>
+                    </li>
+                  )
+                )}
               </ul>
             ) : (
-              <p className="mt-3 text-sm text-slate-600">No items yet.</p>
+              <p className="mt-3 text-sm text-slate-600">No resources yet.</p>
             )
           ) : null}
         </section>

--- a/web/src/api/generated/hooks.ts
+++ b/web/src/api/generated/hooks.ts
@@ -42,26 +42,65 @@ export interface HealthResponse {
   status: HealthResponseStatus;
 }
 
-export interface Item {
+export interface Resource {
   id: number;
   /**
      * @minLength 1
      * @maxLength 120
      */
   title: string;
+  /** @maxLength 500 */
+  description: string;
+  resourceType: string;
   createdAt: string;
 }
 
-export interface ItemListResponse {
-  items: Item[];
+export interface ResourceListResponse {
+  resources: Resource[];
 }
 
-export interface CreateItem {
+export type CreateResourceResourceType = typeof CreateResourceResourceType[keyof typeof CreateResourceResourceType];
+
+
+export const CreateResourceResourceType = {
+  general: 'general',
+  room: 'room',
+  equipment: 'equipment',
+  vehicle: 'vehicle',
+  person: 'person',
+} as const;
+
+export interface CreateResource {
   /**
      * @minLength 1
      * @maxLength 120
      */
   title: string;
+  /** @maxLength 500 */
+  description?: string;
+  resourceType?: CreateResourceResourceType;
+}
+
+export type UpdateResourceResourceType = typeof UpdateResourceResourceType[keyof typeof UpdateResourceResourceType];
+
+
+export const UpdateResourceResourceType = {
+  general: 'general',
+  room: 'room',
+  equipment: 'equipment',
+  vehicle: 'vehicle',
+  person: 'person',
+} as const;
+
+export interface UpdateResource {
+  /**
+     * @minLength 1
+     * @maxLength 120
+     */
+  title?: string;
+  /** @maxLength 500 */
+  description?: string;
+  resourceType?: UpdateResourceResourceType;
 }
 
 export const get = (
@@ -238,14 +277,14 @@ export function useGetHealth<TData = Awaited<ReturnType<typeof getHealth>>, TErr
 
 
 
-export const getItems = (
+export const getResources = (
 
  signal?: AbortSignal
 ) => {
 
 
-      return customClient<ItemListResponse>(
-      {url: `/items`, method: 'GET', signal
+      return customClient<ResourceListResponse>(
+      {url: `/resources`, method: 'GET', signal
     },
       );
     }
@@ -253,66 +292,66 @@ export const getItems = (
 
 
 
-export const getGetItemsQueryKey = () => {
+export const getGetResourcesQueryKey = () => {
     return [
-    `/items`
+    `/resources`
     ] as const;
     }
 
 
-export const getGetItemsQueryOptions = <TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
+export const getGetResourcesQueryOptions = <TData = Awaited<ReturnType<typeof getResources>>, TError = ErrorType<unknown>>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getResources>>, TError, TData>>, }
 ) => {
 
 const {query: queryOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetItemsQueryKey();
+  const queryKey =  queryOptions?.queryKey ?? getGetResourcesQueryKey();
 
 
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getItems>>> = ({ signal }) => getItems(signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getResources>>> = ({ signal }) => getResources(signal);
 
 
 
 
 
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getResources>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
 }
 
-export type GetItemsQueryResult = NonNullable<Awaited<ReturnType<typeof getItems>>>
-export type GetItemsQueryError = ErrorType<unknown>
+export type GetResourcesQueryResult = NonNullable<Awaited<ReturnType<typeof getResources>>>
+export type GetResourcesQueryError = ErrorType<unknown>
 
 
-export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>> & Pick<
+export function useGetResources<TData = Awaited<ReturnType<typeof getResources>>, TError = ErrorType<unknown>>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof getResources>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof getItems>>,
+          Awaited<ReturnType<typeof getResources>>,
           TError,
-          Awaited<ReturnType<typeof getItems>>
+          Awaited<ReturnType<typeof getResources>>
         > , 'initialData'
       >, }
  , queryClient?: QueryClient
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>> & Pick<
+export function useGetResources<TData = Awaited<ReturnType<typeof getResources>>, TError = ErrorType<unknown>>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getResources>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof getItems>>,
+          Awaited<ReturnType<typeof getResources>>,
           TError,
-          Awaited<ReturnType<typeof getItems>>
+          Awaited<ReturnType<typeof getResources>>
         > , 'initialData'
       >, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
+export function useGetResources<TData = Awaited<ReturnType<typeof getResources>>, TError = ErrorType<unknown>>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getResources>>, TError, TData>>, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 
-export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
+export function useGetResources<TData = Awaited<ReturnType<typeof getResources>>, TError = ErrorType<unknown>>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getResources>>, TError, TData>>, }
  , queryClient?: QueryClient
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const queryOptions = getGetItemsQueryOptions(options)
+  const queryOptions = getGetResourcesQueryOptions(options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
@@ -325,27 +364,27 @@ export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError
 
 
 
-export const postItems = (
-    createItem: CreateItem,
+export const postResources = (
+    createResource: CreateResource,
  signal?: AbortSignal
 ) => {
 
 
-      return customClient<Item>(
-      {url: `/items`, method: 'POST',
+      return customClient<Resource>(
+      {url: `/resources`, method: 'POST',
       headers: {'Content-Type': 'application/json', },
-      data: createItem, signal
+      data: createResource, signal
     },
       );
     }
 
 
 
-export const getPostItemsMutationOptions = <TError = ErrorType<unknown>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postItems>>, TError,{data: CreateItem}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof postItems>>, TError,{data: CreateItem}, TContext> => {
+export const getPostResourcesMutationOptions = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postResources>>, TError,{data: CreateResource}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof postResources>>, TError,{data: CreateResource}, TContext> => {
 
-const mutationKey = ['postItems'];
+const mutationKey = ['postResources'];
 const {mutation: mutationOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -355,10 +394,10 @@ const {mutation: mutationOptions} = options ?
 
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postItems>>, {data: CreateItem}> = (props) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postResources>>, {data: CreateResource}> = (props) => {
           const {data} = props ?? {};
 
-          return  postItems(data,)
+          return  postResources(data,)
         }
 
 
@@ -368,40 +407,99 @@ const {mutation: mutationOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type PostItemsMutationResult = NonNullable<Awaited<ReturnType<typeof postItems>>>
-    export type PostItemsMutationBody = CreateItem
-    export type PostItemsMutationError = ErrorType<unknown>
+    export type PostResourcesMutationResult = NonNullable<Awaited<ReturnType<typeof postResources>>>
+    export type PostResourcesMutationBody = CreateResource
+    export type PostResourcesMutationError = ErrorType<unknown>
 
-    export const usePostItems = <TError = ErrorType<unknown>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postItems>>, TError,{data: CreateItem}, TContext>, }
+    export const usePostResources = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postResources>>, TError,{data: CreateResource}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof postItems>>,
+        Awaited<ReturnType<typeof postResources>>,
         TError,
-        {data: CreateItem},
+        {data: CreateResource},
         TContext
       > => {
-      return useMutation(getPostItemsMutationOptions(options), queryClient);
+      return useMutation(getPostResourcesMutationOptions(options), queryClient);
     }
 
-export const deleteItemsId = (
+export const patchResourcesId = (
+    id: number,
+    updateResource: UpdateResource,
+ signal?: AbortSignal
+) => {
+
+
+      return customClient<Resource>(
+      {url: `/resources/${id}`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: updateResource, signal
+    },
+      );
+    }
+
+
+
+export const getPatchResourcesIdMutationOptions = <TError = ErrorType<void>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof patchResourcesId>>, TError,{id: number;data: UpdateResource}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof patchResourcesId>>, TError,{id: number;data: UpdateResource}, TContext> => {
+
+const mutationKey = ['patchResourcesId'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof patchResourcesId>>, {id: number;data: UpdateResource}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  patchResourcesId(id,data,)
+        }
+
+
+
+
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type PatchResourcesIdMutationResult = NonNullable<Awaited<ReturnType<typeof patchResourcesId>>>
+    export type PatchResourcesIdMutationBody = UpdateResource
+    export type PatchResourcesIdMutationError = ErrorType<void>
+
+    export const usePatchResourcesId = <TError = ErrorType<void>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof patchResourcesId>>, TError,{id: number;data: UpdateResource}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof patchResourcesId>>,
+        TError,
+        {id: number;data: UpdateResource},
+        TContext
+      > => {
+      return useMutation(getPatchResourcesIdMutationOptions(options), queryClient);
+    }
+
+export const deleteResourcesId = (
     id: number,
  signal?: AbortSignal
 ) => {
 
 
       return customClient<void>(
-      {url: `/items/${id}`, method: 'DELETE', signal
+      {url: `/resources/${id}`, method: 'DELETE', signal
     },
       );
     }
 
 
 
-export const getDeleteItemsIdMutationOptions = <TError = ErrorType<unknown>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteItemsId>>, TError,{id: number}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof deleteItemsId>>, TError,{id: number}, TContext> => {
+export const getDeleteResourcesIdMutationOptions = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteResourcesId>>, TError,{id: number}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof deleteResourcesId>>, TError,{id: number}, TContext> => {
 
-const mutationKey = ['deleteItemsId'];
+const mutationKey = ['deleteResourcesId'];
 const {mutation: mutationOptions} = options ?
       options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
       options
@@ -411,10 +509,10 @@ const {mutation: mutationOptions} = options ?
 
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteItemsId>>, {id: number}> = (props) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteResourcesId>>, {id: number}> = (props) => {
           const {id} = props ?? {};
 
-          return  deleteItemsId(id,)
+          return  deleteResourcesId(id,)
         }
 
 
@@ -424,17 +522,17 @@ const {mutation: mutationOptions} = options ?
 
   return  { mutationFn, ...mutationOptions }}
 
-    export type DeleteItemsIdMutationResult = NonNullable<Awaited<ReturnType<typeof deleteItemsId>>>
+    export type DeleteResourcesIdMutationResult = NonNullable<Awaited<ReturnType<typeof deleteResourcesId>>>
 
-    export type DeleteItemsIdMutationError = ErrorType<unknown>
+    export type DeleteResourcesIdMutationError = ErrorType<unknown>
 
-    export const useDeleteItemsId = <TError = ErrorType<unknown>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteItemsId>>, TError,{id: number}, TContext>, }
+    export const useDeleteResourcesId = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteResourcesId>>, TError,{id: number}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof deleteItemsId>>,
+        Awaited<ReturnType<typeof deleteResourcesId>>,
         TError,
         {id: number},
         TContext
       > => {
-      return useMutation(getDeleteItemsIdMutationOptions(options), queryClient);
+      return useMutation(getDeleteResourcesIdMutationOptions(options), queryClient);
     }

--- a/web/src/api/generated/hooks.ts
+++ b/web/src/api/generated/hooks.ts
@@ -495,7 +495,7 @@ export const deleteResourcesId = (
 
 
 
-export const getDeleteResourcesIdMutationOptions = <TError = ErrorType<unknown>,
+export const getDeleteResourcesIdMutationOptions = <TError = ErrorType<void>,
     TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteResourcesId>>, TError,{id: number}, TContext>, }
 ): UseMutationOptions<Awaited<ReturnType<typeof deleteResourcesId>>, TError,{id: number}, TContext> => {
 
@@ -524,9 +524,9 @@ const {mutation: mutationOptions} = options ?
 
     export type DeleteResourcesIdMutationResult = NonNullable<Awaited<ReturnType<typeof deleteResourcesId>>>
 
-    export type DeleteResourcesIdMutationError = ErrorType<unknown>
+    export type DeleteResourcesIdMutationError = ErrorType<void>
 
-    export const useDeleteResourcesId = <TError = ErrorType<unknown>,
+    export const useDeleteResourcesId = <TError = ErrorType<void>,
     TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteResourcesId>>, TError,{id: number}, TContext>, }
  , queryClient?: QueryClient): UseMutationResult<
         Awaited<ReturnType<typeof deleteResourcesId>>,


### PR DESCRIPTION
## Summary

- Replaces the `Item` model with a `Resource` model, adding `description` (string, max 500) and `resourceType` (enum: general/room/equipment/vehicle/person) fields
- Adds a `PATCH /resources/{id}` endpoint for partial updates with a 404 on missing resources
- Updates the React frontend to support creating resources with type/description, inline editing, and type badge display
- Includes Prisma migration and regenerated Orval TanStack Query hooks

## Test plan

- [ ] Reset the database (`rm api/data/workshop.db && npm run dev`) and verify the app loads
- [ ] Create a resource with a name, description, and resource type — confirm it appears with the correct type badge
- [ ] Edit an existing resource — confirm title, description, and type are saved correctly
- [ ] Delete a resource — confirm it is removed from the list
- [ ] Verify `GET /resources`, `POST /resources`, `PATCH /resources/:id`, and `DELETE /resources/:id` return expected responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)